### PR TITLE
jinja2>=3.0,<3.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,4 @@ watchdog>=0.10
 livereload>=2.6.3
 nbconvert>=6.1.0
 lxml
-jinja2==3.0
+jinja2>=3.0,<3.1


### PR DESCRIPTION
Malo da relaksiramo zahtev za verziju da se ne sudara sa stvarima poput:

jupyterlab-server 2.15.0 requires jinja2>=3.0.3

